### PR TITLE
Update de action para correr deploy scheduleado

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,9 +1,8 @@
 name: Deploy to GitHub Pages
 
-on: 
-  push:
-    branches:
-      - master
+on:
+  schedule:
+    - cron:  '0 22 * * 1'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
La idea seria cambiar el esquema de releases de posts de "cuando nos acordemos de mergear a master" a todos los lunes a las 22hs lo que haya en master. La idea seria que independientemente de cuando se mergee a master, siempre haya un deploy un lunes a la noche o algo asi. Para discutir igual...